### PR TITLE
fix: Fern poro finds user_id now

### DIFF
--- a/app/poros/fern.rb
+++ b/app/poros/fern.rb
@@ -7,11 +7,16 @@ class Fern
     @preferred_contact_method = fern_info[:attributes][:preferred_contact_method]
     @health = fern_info[:attributes][:health]
     @image = set_image(fern_info[:attributes][:health])
-    @user_id = included.first[:attributes][:google_id] if included
+    @user_id = find_user_id(included) if included
   end
 
   def set_image(health)
     image_number = (health+1)/2
     "love-fern-#{image_number}_720.png"
+  end
+
+  def find_user_id(included)
+    user_hash = included.select { |x| x[:type] == 'user' }
+    user_hash.first[:attributes][:google_id]
   end
 end


### PR DESCRIPTION
## User Story(s) affected
- Fern show

## Describe Changes
- Fern poro user_id attribute assumed user was first entry in included hash, while adding in transactions to the hash made it the second

## Requested Reviewer(s)